### PR TITLE
Update no-store behaviour

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingContext.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingContext.cs
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.ResponseCaching
             // TODO: no-cache requests can be retrieved upon validation with origin
             if (!string.IsNullOrEmpty(request.Headers[HeaderNames.CacheControl]))
             {
-                if (RequestCacheControl.NoCache || RequestCacheControl.NoStore)
+                if (RequestCacheControl.NoCache)
                 {
                     return false;
                 }
@@ -244,7 +244,7 @@ namespace Microsoft.AspNetCore.ResponseCaching
             }
 
             // Check no-store
-            if (ResponseCacheControl.NoStore)
+            if (RequestCacheControl.NoStore || ResponseCacheControl.NoStore)
             {
                 return false;
             }

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingContextTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingContextTests.cs
@@ -57,18 +57,32 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             Assert.False(context.RequestIsCacheable());
         }
 
-        [Theory]
-        [InlineData("no-cache")]
-        [InlineData("no-store")]
-        [InlineData("no-cache, no-store")]
-        public void RequestIsCacheable_ExplicitDisablingDirectives_NotAllowed(string directive)
+        [Fact]
+        public void RequestIsCacheable_NoCache_NotAllowed()
         {
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Method = "GET";
-            httpContext.Request.Headers[HeaderNames.CacheControl] = directive;
+            httpContext.Request.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                NoCache = true
+            };
             var context = new ResponseCachingContext(httpContext, new TestResponseCache());
 
             Assert.False(context.RequestIsCacheable());
+        }
+
+        [Fact]
+        public void RequestIsCacheable_NoStore_Allowed()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Method = "GET";
+            httpContext.Request.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                NoStore = true
+            };
+            var context = new ResponseCachingContext(httpContext, new TestResponseCache());
+
+            Assert.True(context.RequestIsCacheable());
         }
 
         [Fact]
@@ -162,7 +176,24 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         }
 
         [Fact]
-        public void ResponseIsCacheable_NoStore_NotAllowed()
+        public void ResponseIsCacheable_RequestNoStore_NotAllowed()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                NoStore = true
+            };
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true
+            };
+            var context = new ResponseCachingContext(httpContext, new TestResponseCache());
+
+            Assert.False(context.ResponseIsCacheable());
+        }
+
+        [Fact]
+        public void ResponseIsCacheable_ResponseNoStore_NotAllowed()
         {
             var httpContext = new DefaultHttpContext();
             httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()


### PR DESCRIPTION
I didn't follow the RFC regarding `no-store` directive in the request. This simply means the corresponding response cannot be cached. However, if a response exist in the cache already, it can be served.

cc @Tratcher @davidfowl 