### PR TITLE
Split headers body

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCaching/CacheEntry/CachedResponse.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/CacheEntry/CachedResponse.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.ResponseCaching.Internal
+{
+    internal class CachedResponse
+    {
+        internal string BodyKeyPrefix { get; set; }
+
+        internal DateTimeOffset Created { get; set; }
+
+        internal int StatusCode { get; set; }
+
+        internal IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+
+        internal byte[] Body { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.ResponseCaching/CacheEntry/CachedResponseBody.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/CacheEntry/CachedResponseBody.cs
@@ -1,19 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using Microsoft.AspNetCore.Http;
-
 namespace Microsoft.AspNetCore.ResponseCaching.Internal
 {
-    internal class CachedResponse
+    internal class CachedResponseBody
     {
-        internal DateTimeOffset Created { get; set; }
-
-        internal int StatusCode { get; set; }
-
-        internal IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
-
         internal byte[] Body { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.ResponseCaching/CacheEntry/CachedVaryRules.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/CacheEntry/CachedVaryRules.cs
@@ -5,6 +5,8 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
 {
     internal class CachedVaryRules
     {
-        internal VaryRules VaryRules;
+        internal string VaryKeyPrefix { get; set; }
+
+        internal VaryRules VaryRules { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.ResponseCaching/Interfaces/IKeyProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Interfaces/IKeyProvider.cs
@@ -8,18 +8,18 @@ namespace Microsoft.AspNetCore.ResponseCaching
     public interface IKeyProvider
     {
         /// <summary>
-        /// Create a key using the HTTP request.
+        /// Create a base key using the HTTP request.
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext"/>.</param>
         /// <returns>The created base key.</returns>
         string CreateBaseKey(HttpContext httpContext);
 
         /// <summary>
-        /// Create a key using the HTTP context and vary rules.
+        /// Create a vary key using the HTTP context and vary rules.
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext"/>.</param>
         /// <param name="varyRules">The <see cref="VaryRules"/>.</param>
-        /// <returns>The created base key.</returns>
+        /// <returns>The created vary key.</returns>
         string CreateVaryKey(HttpContext httpContext, VaryRules varyRules);
     }
 }

--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/FastGuid.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/FastGuid.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.AspNetCore.ResponseCaching.Internal
+{
+    internal class FastGuid
+    {
+        // Base32 encoding - in ascii sort order for easy text based sorting
+        private static readonly string _encode32Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUV";
+        // Global ID
+        private static long NextId;
+
+        // Instance components
+        private string _idString;
+        internal long IdValue { get; private set; }
+
+        internal string IdString
+        {
+            get
+            {
+                if (_idString == null)
+                {
+                    _idString = GenerateGuidString(this);
+                }
+                return _idString;
+            }
+        }
+
+        // Static constructor to initialize global components
+        static FastGuid()
+        {
+            var guidBytes = Guid.NewGuid().ToByteArray();
+
+            // Use the first 4 bytes from the Guid to initialize global ID
+            NextId =
+                guidBytes[0] << 32 |
+                guidBytes[1] << 40 |
+                guidBytes[2] << 48 |
+                guidBytes[3] << 56;
+        }
+
+        internal FastGuid(long id)
+        {
+            IdValue = id;
+        }
+
+        internal static FastGuid NewGuid()
+        {
+            return new FastGuid(Interlocked.Increment(ref NextId));
+        }
+
+        private static unsafe string GenerateGuidString(FastGuid guid)
+        {
+
+            // stackalloc to allocate array on stack rather than heap
+            char* charBuffer = stackalloc char[13];
+
+            // ID
+            charBuffer[0] = _encode32Chars[(int)(guid.IdValue >> 60) & 31];
+            charBuffer[1] = _encode32Chars[(int)(guid.IdValue >> 55) & 31];
+            charBuffer[2] = _encode32Chars[(int)(guid.IdValue >> 50) & 31];
+            charBuffer[3] = _encode32Chars[(int)(guid.IdValue >> 45) & 31];
+            charBuffer[4] = _encode32Chars[(int)(guid.IdValue >> 40) & 31];
+            charBuffer[5] = _encode32Chars[(int)(guid.IdValue >> 35) & 31];
+            charBuffer[6] = _encode32Chars[(int)(guid.IdValue >> 30) & 31];
+            charBuffer[7] = _encode32Chars[(int)(guid.IdValue >> 25) & 31];
+            charBuffer[8] = _encode32Chars[(int)(guid.IdValue >> 20) & 31];
+            charBuffer[9] = _encode32Chars[(int)(guid.IdValue >> 15) & 31];
+            charBuffer[10] = _encode32Chars[(int)(guid.IdValue >> 10) & 31];
+            charBuffer[11] = _encode32Chars[(int)(guid.IdValue >> 5) & 31];
+            charBuffer[12] = _encode32Chars[(int)guid.IdValue & 31];
+
+            // string ctor overload that takes char*
+            return new string(charBuffer, 0, 13);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/MemoryResponseCache.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/MemoryResponseCache.cs
@@ -33,8 +33,8 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
         public void Set(string key, object entry, TimeSpan validFor)
         {
             _cache.Set(
-                key, 
-                entry, 
+                key,
+                entry,
                 new MemoryCacheEntryOptions()
                 {
                     AbsoluteExpirationRelativeToNow = validFor

--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachingState.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachingState.cs
@@ -38,6 +38,8 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
 
         internal CachedResponse CachedResponse { get;  set; }
 
+        internal CachedVaryRules CachedVaryRules { get; set; }
+
         public RequestHeaders RequestHeaders
         {
             get

--- a/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingOptions.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingOptions.cs
@@ -19,6 +19,11 @@ namespace Microsoft.AspNetCore.Builder
         public bool CaseSensitivePaths { get; set; } = false;
 
         /// <summary>
+        /// The smallest size in bytes for which the headers and body of the response will be stored separately. The default is set to 70 KB.
+        /// </summary>
+        public long MinimumSplitBodySize { get; set; } = 70 * 1024;
+
+        /// <summary>
         /// For testing purposes only.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Microsoft.AspNetCore.ResponseCaching/project.json
+++ b/src/Microsoft.AspNetCore.ResponseCaching/project.json
@@ -2,6 +2,7 @@
   "version": "0.1.0-*",
   "buildOptions": {
     "warningsAsErrors": true,
+    "allowUnsafe": true,
     "keyFile": "../../tools/Key.snk",
     "nowarn": [
       "CS1591"

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/CacheEntrySerializerTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/CacheEntrySerializerTests.cs
@@ -25,78 +25,109 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         }
 
         [Fact]
-        public void RoundTrip_CachedResponses_Succeeds()
+        public void Deserialize_NullObject_ReturnsNull()
+        {
+            Assert.Null(CacheEntrySerializer.Deserialize(null));
+        }
+
+        [Fact]
+        public void RoundTrip_CachedResponseBody_Succeeds()
+        {
+            var cachedResponseBody = new CachedResponseBody()
+            {
+                Body = Encoding.ASCII.GetBytes("Hello world"),
+            };
+
+            AssertCachedResponseBodyEqual(cachedResponseBody, (CachedResponseBody)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedResponseBody)));
+        }
+
+        [Fact]
+        public void RoundTrip_CachedResponseWithoutBody_Succeeds()
         {
             var headers = new HeaderDictionary();
             headers["keyA"] = "valueA";
             headers["keyB"] = "valueB";
-            var cachedEntry = new CachedResponse()
+            var cachedResponse = new CachedResponse()
             {
+                BodyKeyPrefix = FastGuid.NewGuid().IdString,
+                Created = DateTimeOffset.UtcNow,
+                StatusCode = StatusCodes.Status200OK,
+                Headers = headers
+            };
+
+            AssertCachedResponseEqual(cachedResponse, (CachedResponse)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedResponse)));
+        }
+
+        [Fact]
+        public void RoundTrip_CachedResponseWithBody_Succeeds()
+        {
+            var headers = new HeaderDictionary();
+            headers["keyA"] = "valueA";
+            headers["keyB"] = "valueB";
+            var cachedResponse = new CachedResponse()
+            {
+                BodyKeyPrefix = FastGuid.NewGuid().IdString,
                 Created = DateTimeOffset.UtcNow,
                 StatusCode = StatusCodes.Status200OK,
                 Body = Encoding.ASCII.GetBytes("Hello world"),
                 Headers = headers
             };
 
-            AssertCachedResponsesEqual(cachedEntry, (CachedResponse)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedEntry)));
+            AssertCachedResponseEqual(cachedResponse, (CachedResponse)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedResponse)));
         }
 
         [Fact]
-        public void RoundTrip_Empty_CachedVaryRules_Succeeds()
+        public void RoundTrip_CachedVaryRule_EmptyRules_Succeeds()
         {
-            var cachedVaryRules = new CachedVaryRules();
-
-            AssertCachedVaryRulesEqual(cachedVaryRules, (CachedVaryRules)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedVaryRules)));
-        }
-
-        [Fact]
-        public void RoundTrip_CachedVaryRules_EmptyRules_Succeeds()
-        {
-            var cachedVaryRules = new CachedVaryRules()
+            var cachedVaryRule = new CachedVaryRules()
             {
+                VaryKeyPrefix = FastGuid.NewGuid().IdString,
                 VaryRules = new VaryRules()
             };
 
-            AssertCachedVaryRulesEqual(cachedVaryRules, (CachedVaryRules)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedVaryRules)));
+            AssertCachedVaryRuleEqual(cachedVaryRule, (CachedVaryRules)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedVaryRule)));
         }
 
         [Fact]
-        public void RoundTrip_HeadersOnly_CachedVaryRules_Succeeds()
+        public void RoundTrip_CachedVaryRule_HeadersOnly_Succeeds()
         {
             var headers = new[] { "headerA", "headerB" };
-            var cachedVaryRules = new CachedVaryRules()
+            var cachedVaryRule = new CachedVaryRules()
             {
+                VaryKeyPrefix = FastGuid.NewGuid().IdString,
                 VaryRules = new VaryRules()
                 {
                     Headers = headers
                 }
             };
 
-            AssertCachedVaryRulesEqual(cachedVaryRules, (CachedVaryRules)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedVaryRules)));
+            AssertCachedVaryRuleEqual(cachedVaryRule, (CachedVaryRules)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedVaryRule)));
         }
 
         [Fact]
-        public void RoundTrip_ParamsOnly_CachedVaryRules_Succeeds()
+        public void RoundTrip_CachedVaryRule_ParamsOnly_Succeeds()
         {
             var param = new[] { "paramA", "paramB" };
-            var cachedVaryRules = new CachedVaryRules()
+            var cachedVaryRule = new CachedVaryRules()
             {
+                VaryKeyPrefix = FastGuid.NewGuid().IdString,
                 VaryRules = new VaryRules()
                 {
                     Params = param
                 }
             };
 
-            AssertCachedVaryRulesEqual(cachedVaryRules, (CachedVaryRules)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedVaryRules)));
+            AssertCachedVaryRuleEqual(cachedVaryRule, (CachedVaryRules)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedVaryRule)));
         }
 
         [Fact]
-        public void RoundTrip_HeadersAndParams_CachedVaryRules_Succeeds()
+        public void RoundTrip_CachedVaryRule_HeadersAndParams_Succeeds()
         {
             var headers = new[] { "headerA", "headerB" };
             var param = new[] { "paramA", "paramB" };
-            var cachedVaryRules = new CachedVaryRules()
+            var cachedVaryRule = new CachedVaryRules()
             {
+                VaryKeyPrefix = FastGuid.NewGuid().IdString,
                 VaryRules = new VaryRules()
                 {
                     Headers = headers,
@@ -104,30 +135,37 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 }
             };
 
-            AssertCachedVaryRulesEqual(cachedVaryRules, (CachedVaryRules)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedVaryRules)));
+            AssertCachedVaryRuleEqual(cachedVaryRule, (CachedVaryRules)CacheEntrySerializer.Deserialize(CacheEntrySerializer.Serialize(cachedVaryRule)));
         }
 
         [Fact]
         public void Deserialize_InvalidEntries_ReturnsNull()
         {
             var headers = new[] { "headerA", "headerB" };
-            var cachedVaryRules = new CachedVaryRules()
+            var cachedVaryRule = new CachedVaryRules()
             {
+                VaryKeyPrefix = FastGuid.NewGuid().IdString,
                 VaryRules = new VaryRules()
                 {
                     Headers = headers
                 }
             };
-            var serializedEntry = CacheEntrySerializer.Serialize(cachedVaryRules);
+            var serializedEntry = CacheEntrySerializer.Serialize(cachedVaryRule);
             Array.Reverse(serializedEntry);
 
             Assert.Null(CacheEntrySerializer.Deserialize(serializedEntry));
         }
 
-        private static void AssertCachedResponsesEqual(CachedResponse expected, CachedResponse actual)
+        private static void AssertCachedResponseBodyEqual(CachedResponseBody expected, CachedResponseBody actual)
+        {
+            Assert.True(expected.Body.SequenceEqual(actual.Body));
+        }
+
+        private static void AssertCachedResponseEqual(CachedResponse expected, CachedResponse actual)
         {
             Assert.NotNull(actual);
             Assert.NotNull(expected);
+            Assert.Equal(expected.BodyKeyPrefix, actual.BodyKeyPrefix);
             Assert.Equal(expected.Created, actual.Created);
             Assert.Equal(expected.StatusCode, actual.StatusCode);
             Assert.Equal(expected.Headers.Count, actual.Headers.Count);
@@ -135,23 +173,23 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             {
                 Assert.Equal(expectedHeader.Value, actual.Headers[expectedHeader.Key]);
             }
-            Assert.True(expected.Body.SequenceEqual(actual.Body));
-        }
-
-        private static void AssertCachedVaryRulesEqual(CachedVaryRules expected, CachedVaryRules actual)
-        {
-            Assert.NotNull(actual);
-            Assert.NotNull(expected);
-            if (expected.VaryRules == null)
+            if (expected.Body == null)
             {
-                Assert.Null(actual.VaryRules);
+                Assert.Null(actual.Body);
             }
             else
             {
-                Assert.NotNull(actual.VaryRules);
-                Assert.Equal(expected.VaryRules.Headers, actual.VaryRules.Headers);
-                Assert.Equal(expected.VaryRules.Params, actual.VaryRules.Params);
+                Assert.True(expected.Body.SequenceEqual(actual.Body));
             }
+        }
+
+        private static void AssertCachedVaryRuleEqual(CachedVaryRules expected, CachedVaryRules actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+            Assert.Equal(expected.VaryKeyPrefix, actual.VaryKeyPrefix);
+            Assert.Equal(expected.VaryRules.Headers, actual.VaryRules.Headers);
+            Assert.Equal(expected.VaryRules.Params, actual.VaryRules.Params);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingContextTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingContextTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Xunit;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.ResponseCaching.Tests
 {
@@ -154,10 +155,312 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             Assert.False(context.ConditionalRequestSatisfied(cachedHeaders));
         }
 
+        [Fact]
+        public void FinalizeCachingHeaders_DoNotUpdateShouldCacheResponse_IfResponseIsNotCacheable()
+        {
+            var httpContext = new DefaultHttpContext();
+            var context = CreateTestContext(httpContext);
+            var state = httpContext.GetResponseCachingState();
+
+            Assert.False(state.ShouldCacheResponse);
+
+            context.ShimResponseStream();
+            context.FinalizeCachingHeaders();
+
+            Assert.False(state.ShouldCacheResponse);
+        }
+
+        [Fact]
+        public void FinalizeCachingHeaders_UpdateShouldCacheResponse_IfResponseIsCacheable()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true
+            };
+            var context = CreateTestContext(httpContext);
+            var state = httpContext.GetResponseCachingState();
+
+            Assert.False(state.ShouldCacheResponse);
+
+            context.FinalizeCachingHeaders();
+
+            Assert.True(state.ShouldCacheResponse);
+        }
+
+        [Fact]
+        public void FinalizeCachingHeaders_DefaultResponseValidity_Is10Seconds()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true
+            };
+            var context = CreateTestContext(httpContext);
+
+            context.FinalizeCachingHeaders();
+
+            Assert.Equal(TimeSpan.FromSeconds(10), httpContext.GetResponseCachingState().CachedResponseValidFor);
+        }
+
+        [Fact]
+        public void FinalizeCachingHeaders_ResponseValidity_UseExpiryIfAvailable()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true
+            };
+            var context = CreateTestContext(httpContext);
+
+            var state = httpContext.GetResponseCachingState();
+            var utcNow = DateTimeOffset.MinValue;
+            state.ResponseTime = utcNow;
+            state.ResponseHeaders.Expires = utcNow + TimeSpan.FromSeconds(11);
+
+            context.FinalizeCachingHeaders();
+
+            Assert.Equal(TimeSpan.FromSeconds(11), state.CachedResponseValidFor);
+        }
+
+        [Fact]
+        public void FinalizeCachingHeaders_ResponseValidity_UseMaxAgeIfAvailable()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true,
+                MaxAge = TimeSpan.FromSeconds(12)
+            };
+            var context = CreateTestContext(httpContext);
+
+            var state = httpContext.GetResponseCachingState();
+            state.ResponseTime = DateTimeOffset.UtcNow;
+            state.ResponseHeaders.Expires = state.ResponseTime + TimeSpan.FromSeconds(11);
+
+            context.FinalizeCachingHeaders();
+
+            Assert.Equal(TimeSpan.FromSeconds(12), state.CachedResponseValidFor);
+        }
+
+        [Fact]
+        public void FinalizeCachingHeaders_ResponseValidity_UseSharedMaxAgeIfAvailable()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true,
+                MaxAge = TimeSpan.FromSeconds(12),
+                SharedMaxAge = TimeSpan.FromSeconds(13)
+            };
+            var context = CreateTestContext(httpContext);
+
+            var state = httpContext.GetResponseCachingState();
+            state.ResponseTime = DateTimeOffset.UtcNow;
+            state.ResponseHeaders.Expires = state.ResponseTime + TimeSpan.FromSeconds(11);
+
+            context.FinalizeCachingHeaders();
+
+            Assert.Equal(TimeSpan.FromSeconds(13), state.CachedResponseValidFor);
+        }
+
+        [Fact]
+        public void FinalizeCachingHeaders_UpdateCachedVaryRules_IfNotEquivalentToPrevious()
+        {
+            var httpContext = new DefaultHttpContext();
+            var cache = new TestResponseCache();
+            var context = CreateTestContext(httpContext, cache, new ResponseCachingOptions());
+            var state = httpContext.GetResponseCachingState();
+
+            httpContext.Response.Headers[HeaderNames.Vary] = new StringValues(new[] { "headerA", "HEADERB", "HEADERc" });
+            httpContext.AddResponseCachingFeature();
+            httpContext.GetResponseCachingFeature().VaryParams = new StringValues(new[] { "paramB", "PARAMAA" });
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true,
+            };
+            var cachedVaryRules = new CachedVaryRules()
+            {
+                VaryRules = new VaryRules()
+                {
+                    Headers = new StringValues(new[] { "HeaderA", "HeaderB" }),
+                    Params = new StringValues(new[] { "ParamA", "ParamB" })
+                }
+            };
+            state.CachedVaryRules = cachedVaryRules;
+
+            context.FinalizeCachingHeaders();
+
+            Assert.Equal(1, cache.StoredItems);
+            Assert.NotSame(cachedVaryRules, state.CachedVaryRules);
+        }
+
+        [Fact]
+        public void FinalizeCachingHeaders_DoNotUpdateCachedVaryRules_IfEquivalentToPrevious()
+        {
+            var httpContext = new DefaultHttpContext();
+            var cache = new TestResponseCache();
+            var context = CreateTestContext(httpContext, cache, new ResponseCachingOptions());
+            var state = httpContext.GetResponseCachingState();
+
+            httpContext.Response.Headers[HeaderNames.Vary] = new StringValues(new[] { "headerA", "HEADERB" });
+            httpContext.AddResponseCachingFeature();
+            httpContext.GetResponseCachingFeature().VaryParams = new StringValues(new[] { "paramB", "PARAMA" });
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true,
+            };
+            var cachedVaryRules = new CachedVaryRules()
+            {
+                VaryKeyPrefix = FastGuid.NewGuid().IdString,
+                VaryRules = new VaryRules()
+                {
+                    Headers = new StringValues(new[] { "HEADERA", "HEADERB" }),
+                    Params = new StringValues(new[] { "PARAMA", "PARAMB" })
+                }
+            };
+            state.CachedVaryRules = cachedVaryRules;
+
+            context.FinalizeCachingHeaders();
+
+            Assert.Equal(0, cache.StoredItems);
+            Assert.Same(cachedVaryRules, state.CachedVaryRules);
+        }
+
+        [Fact]
+        public void FinalizeCachingHeaders_DoNotAddDate_IfSpecified()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true
+            };
+            var context = CreateTestContext(httpContext);
+            var state = httpContext.GetResponseCachingState();
+            var utcNow = DateTimeOffset.MinValue;
+            state.ResponseTime = utcNow;
+
+            Assert.Null(state.ResponseHeaders.Date);
+
+            context.FinalizeCachingHeaders();
+
+            Assert.Equal(utcNow, state.ResponseHeaders.Date);
+        }
+
+        [Fact]
+        public void FinalizeCachingHeaders_AddsDate_IfNoneSpecified()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true
+            };
+            var context = CreateTestContext(httpContext);
+            var state = httpContext.GetResponseCachingState();
+            var utcNow = DateTimeOffset.MinValue;
+            state.ResponseHeaders.Date = utcNow;
+            state.ResponseTime = utcNow + TimeSpan.FromSeconds(10);
+
+            Assert.Equal(utcNow, state.ResponseHeaders.Date);
+
+            context.FinalizeCachingHeaders();
+
+            Assert.Equal(utcNow, state.ResponseHeaders.Date);
+        }
+
+        [Fact]
+        public void FinalizeCachingHeaders_StoresCachedResponse_InState()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
+            {
+                Public = true
+            };
+            var context = CreateTestContext(httpContext);
+            var state = httpContext.GetResponseCachingState();
+
+            Assert.Null(state.CachedResponse);
+
+            context.FinalizeCachingHeaders();
+
+            Assert.NotNull(state.CachedResponse);
+        }
+
+        [Fact]
+        public async Task FinalizeCachingBody_StoreResponseBodySeparately_IfLargerThanLimit()
+        {
+            var httpContext = new DefaultHttpContext();
+            var cache = new TestResponseCache();
+            var context = CreateTestContext(httpContext, cache, new ResponseCachingOptions());
+
+            context.ShimResponseStream();
+            await httpContext.Response.WriteAsync(new string('0', 70 * 1024));
+
+            var state = httpContext.GetResponseCachingState();
+            state.ShouldCacheResponse = true;
+            state.CachedResponse = new CachedResponse()
+            {
+                BodyKeyPrefix = FastGuid.NewGuid().IdString
+            };
+            state.BaseKey = "BaseKey";
+            state.CachedResponseValidFor = TimeSpan.FromSeconds(10);
+
+            context.FinalizeCachingBody();
+
+            Assert.Equal(2, cache.StoredItems);
+        }
+
+        [Fact]
+        public async Task FinalizeCachingBody_StoreResponseBodyInCachedResponse_IfSmallerThanLimit()
+        {
+            var httpContext = new DefaultHttpContext();
+            var cache = new TestResponseCache();
+            var context = CreateTestContext(httpContext, cache, new ResponseCachingOptions());
+
+            context.ShimResponseStream();
+            await httpContext.Response.WriteAsync(new string('0', 70 * 1024 - 1));
+
+            var state = httpContext.GetResponseCachingState();
+            state.ShouldCacheResponse = true;
+            state.CachedResponse = new CachedResponse()
+            {
+                BodyKeyPrefix = FastGuid.NewGuid().IdString
+            };
+            state.BaseKey = "BaseKey";
+            state.CachedResponseValidFor = TimeSpan.FromSeconds(10);
+
+            context.FinalizeCachingBody();
+
+            Assert.Equal(1, cache.StoredItems);
+        }
+
+        [Fact]
+        public void NormalizeStringValues_NormalizesCasingToUpper()
+        {
+            var uppercaseStrings = new StringValues(new[] { "STRINGA", "STRINGB" });
+            var lowercaseStrings = new StringValues(new[] { "stringA", "stringB" });
+
+            var normalizedStrings = ResponseCachingContext.GetNormalizedStringValues(lowercaseStrings);
+
+            Assert.Equal(uppercaseStrings, normalizedStrings);
+        }
+
+        [Fact]
+        public void NormalizeStringValues_NormalizesOrder()
+        {
+            var orderedStrings = new StringValues(new[] { "STRINGA", "STRINGB" });
+            var reverseOrderStrings = new StringValues(new[] { "STRINGB", "STRINGA" });
+
+            var normalizedStrings = ResponseCachingContext.GetNormalizedStringValues(reverseOrderStrings);
+
+            Assert.Equal(orderedStrings, normalizedStrings);
+        }
+
         private static ResponseCachingContext CreateTestContext(HttpContext httpContext)
         {
             return CreateTestContext(
                 httpContext,
+                new TestResponseCache(),
                 new ResponseCachingOptions(),
                 new CacheabilityValidator());
         }
@@ -166,6 +469,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         {
             return CreateTestContext(
                 httpContext,
+                new TestResponseCache(),
                 options,
                 new CacheabilityValidator());
         }
@@ -174,12 +478,23 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         {
             return CreateTestContext(
                 httpContext,
+                new TestResponseCache(),
                 new ResponseCachingOptions(),
                 cacheabilityValidator);
         }
 
+        private static ResponseCachingContext CreateTestContext(HttpContext httpContext, IResponseCache responseCache, ResponseCachingOptions options)
+        {
+            return CreateTestContext(
+                httpContext,
+                responseCache,
+                options,
+                new CacheabilityValidator());
+        }
+
         private static ResponseCachingContext CreateTestContext(
             HttpContext httpContext,
+            IResponseCache responseCache,
             ResponseCachingOptions options,
             ICacheabilityValidator cacheabilityValidator)
         {
@@ -187,7 +502,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
 
             return new ResponseCachingContext(
                 httpContext,
-                new TestResponseCache(),
+                responseCache,
                 options,
                 cacheabilityValidator,
                 new KeyProvider(new DefaultObjectPoolProvider(), Options.Create(options)));
@@ -195,6 +510,8 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
 
         private class TestResponseCache : IResponseCache
         {
+            public int StoredItems { get; private set; }
+
             public object Get(string key)
             {
                 return null;
@@ -206,6 +523,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
 
             public void Set(string key, object entry, TimeSpan validFor)
             {
+                StoredItems++;
             }
         }
 


### PR DESCRIPTION
- [x] Add an implementation of FastGuid
- [x] Use Guid based key generation
- [x] Update logic for normalizing and comparing cachedVaryBy entries 
- [x] Add an option to configure the size at which head and body are stored separately

cc @Tratcher @davidfowl 