### PR TITLE
Enumerable lookup keys

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCaching/Interfaces/IKeyProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Interfaces/IKeyProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.ResponseCaching
@@ -8,18 +9,33 @@ namespace Microsoft.AspNetCore.ResponseCaching
     public interface IKeyProvider
     {
         /// <summary>
-        /// Create a base key using the HTTP request.
+        /// Create a base key using the HTTP context for storing items.
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext"/>.</param>
         /// <returns>The created base key.</returns>
-        string CreateBaseKey(HttpContext httpContext);
+        string CreateStorageBaseKey(HttpContext httpContext);
 
         /// <summary>
-        /// Create a vary key using the HTTP context and vary rules.
+        /// Create one or more base keys using the HTTP context for looking up items.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/>.</param>
+        /// <returns>An ordered <see cref="IEnumerable{T}"/> containing the base keys to try when looking up items.</returns>
+        IEnumerable<string> CreateLookupBaseKey(HttpContext httpContext);
+
+        /// <summary>
+        /// Create a vary key using the HTTP context and vary rules for storing items.
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext"/>.</param>
         /// <param name="varyRules">The <see cref="VaryRules"/>.</param>
         /// <returns>The created vary key.</returns>
-        string CreateVaryKey(HttpContext httpContext, VaryRules varyRules);
+        string CreateStorageVaryKey(HttpContext httpContext, VaryRules varyRules);
+
+        /// <summary>
+        /// Create one or more vary keys using the HTTP context and vary rules for looking up items.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/>.</param>
+        /// <param name="varyRules">The <see cref="VaryRules"/>.</param>
+        /// <returns>An ordered <see cref="IEnumerable{T}"/> containing the vary keys to try when looking up items.</returns>
+        IEnumerable<string> CreateLookupVaryKey(HttpContext httpContext, VaryRules varyRules);
     }
 }

--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachingState.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachingState.cs
@@ -26,9 +26,9 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
 
         public bool ShouldCacheResponse { get; internal set; }
 
-        public string BaseKey { get; internal set; }
+        public string StorageBaseKey { get; internal set; }
 
-        public string VaryKey { get; internal set; }
+        public string StorageVaryKey { get; internal set; }
 
         public DateTimeOffset ResponseTime { get; internal set; }
 

--- a/src/Microsoft.AspNetCore.ResponseCaching/KeyProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/KeyProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
@@ -35,9 +36,19 @@ namespace Microsoft.AspNetCore.ResponseCaching
             _options = options.Value;
         }
 
+        public virtual IEnumerable<string> CreateLookupBaseKey(HttpContext httpContext)
+        {
+            return new string[] { CreateStorageBaseKey(httpContext) };
+        }
+
+        public virtual IEnumerable<string> CreateLookupVaryKey(HttpContext httpContext, VaryRules varyRules)
+        {
+            return new string[] { CreateStorageVaryKey(httpContext, varyRules) };
+        }
+
         // GET<delimiter>/PATH
         // TODO: Method invariant retrieval? E.g. HEAD after GET to the same resource.
-        public virtual string CreateBaseKey(HttpContext httpContext)
+        public virtual string CreateStorageBaseKey(HttpContext httpContext)
         {
             if (httpContext == null)
             {
@@ -63,7 +74,7 @@ namespace Microsoft.AspNetCore.ResponseCaching
         }
 
         // BaseKey<delimiter>H<delimiter>HeaderName=HeaderValue<delimiter>Q<delimiter>QueryName=QueryValue
-        public virtual string CreateVaryKey(HttpContext httpContext, VaryRules varyRules)
+        public virtual string CreateStorageVaryKey(HttpContext httpContext, VaryRules varyRules)
         {
             if (httpContext == null)
             {

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/KeyProviderTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/KeyProviderTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         };
 
         [Fact]
-        public void DefaultKeyProvider_CreateBaseKey_IncludesOnlyNormalizedMethodAndPath()
+        public void DefaultKeyProvider_CreateStorageBaseKey_IncludesOnlyNormalizedMethodAndPath()
         {
             var httpContext = CreateDefaultContext();
             httpContext.Request.Method = "head";
@@ -30,11 +30,11 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             httpContext.Request.QueryString = new QueryString("?query.Key=a&query.Value=b");
             var keyProvider = CreateTestKeyProvider();
 
-            Assert.Equal($"HEAD{KeyDelimiter}/PATH/SUBPATH", keyProvider.CreateBaseKey(httpContext));
+            Assert.Equal($"HEAD{KeyDelimiter}/PATH/SUBPATH", keyProvider.CreateStorageBaseKey(httpContext));
         }
 
         [Fact]
-        public void DefaultKeyProvider_CreateBaseKey_CaseInsensitivePath_NormalizesPath()
+        public void DefaultKeyProvider_CreateStorageBaseKey_CaseInsensitivePath_NormalizesPath()
         {
             var httpContext = CreateDefaultContext();
             httpContext.Request.Method = "GET";
@@ -44,11 +44,11 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 CaseSensitivePaths = false
             });
 
-            Assert.Equal($"GET{KeyDelimiter}/PATH", keyProvider.CreateBaseKey(httpContext));
+            Assert.Equal($"GET{KeyDelimiter}/PATH", keyProvider.CreateStorageBaseKey(httpContext));
         }
 
         [Fact]
-        public void DefaultKeyProvider_CreateBaseKey_CaseSensitivePath_PreservesPathCase()
+        public void DefaultKeyProvider_CreateStorageBaseKey_CaseSensitivePath_PreservesPathCase()
         {
             var httpContext = CreateDefaultContext();
             httpContext.Request.Method = "GET";
@@ -58,21 +58,21 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 CaseSensitivePaths = true
             });
 
-            Assert.Equal($"GET{KeyDelimiter}/Path", keyProvider.CreateBaseKey(httpContext));
+            Assert.Equal($"GET{KeyDelimiter}/Path", keyProvider.CreateStorageBaseKey(httpContext));
         }
 
         [Fact]
-        public void DefaultKeyProvider_CreateVaryKey_ReturnsCachedVaryGuid_IfVaryRulesIsNullOrEmpty()
+        public void DefaultKeyProvider_CreateStorageVaryKey_ReturnsCachedVaryGuid_IfVaryRulesIsNullOrEmpty()
         {
             var httpContext = CreateDefaultContext();
             var keyProvider = CreateTestKeyProvider();
 
-            Assert.Equal($"{TestVaryRules.VaryKeyPrefix}", keyProvider.CreateVaryKey(httpContext, null));
-            Assert.Equal($"{TestVaryRules.VaryKeyPrefix}", keyProvider.CreateVaryKey(httpContext, new VaryRules()));
+            Assert.Equal($"{TestVaryRules.VaryKeyPrefix}", keyProvider.CreateStorageVaryKey(httpContext, null));
+            Assert.Equal($"{TestVaryRules.VaryKeyPrefix}", keyProvider.CreateStorageVaryKey(httpContext, new VaryRules()));
         }
 
         [Fact]
-        public void DefaultKeyProvider_CreateVaryKey_IncludesListedHeadersOnly()
+        public void DefaultKeyProvider_CreateStorageVaryKey_IncludesListedHeadersOnly()
         {
             var httpContext = CreateDefaultContext();
             httpContext.Request.Headers["HeaderA"] = "ValueA";
@@ -80,42 +80,42 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             var keyProvider = CreateTestKeyProvider();
 
             Assert.Equal($"{TestVaryRules.VaryKeyPrefix}{KeyDelimiter}H{KeyDelimiter}HeaderA=ValueA{KeyDelimiter}HeaderC=null",
-                keyProvider.CreateVaryKey(httpContext, new VaryRules()
+                keyProvider.CreateStorageVaryKey(httpContext, new VaryRules()
                 {
                     Headers = new string[] { "HeaderA", "HeaderC" }
                 }));
         }
 
         [Fact]
-        public void DefaultKeyProvider_CreateVaryKey_IncludesListedParamsOnly()
+        public void DefaultKeyProvider_CreateStorageVaryKey_IncludesListedParamsOnly()
         {
             var httpContext = CreateDefaultContext();
             httpContext.Request.QueryString = new QueryString("?ParamA=ValueA&ParamB=ValueB");
             var keyProvider = CreateTestKeyProvider();
 
             Assert.Equal($"{TestVaryRules.VaryKeyPrefix}{KeyDelimiter}Q{KeyDelimiter}ParamA=ValueA{KeyDelimiter}ParamC=null",
-                keyProvider.CreateVaryKey(httpContext, new VaryRules()
+                keyProvider.CreateStorageVaryKey(httpContext, new VaryRules()
                 {
                     Params = new string[] { "ParamA", "ParamC" }
                 }));
         }
 
         [Fact]
-        public void DefaultKeyProvider_CreateVaryKey_IncludesParams_ParamNameCaseInsensitive_UseParamCasing()
+        public void DefaultKeyProvider_CreateStorageVaryKey_IncludesParams_ParamNameCaseInsensitive_UseParamCasing()
         {
             var httpContext = CreateDefaultContext();
             httpContext.Request.QueryString = new QueryString("?parama=ValueA&paramB=ValueB");
             var keyProvider = CreateTestKeyProvider();
 
             Assert.Equal($"{TestVaryRules.VaryKeyPrefix}{KeyDelimiter}Q{KeyDelimiter}ParamA=ValueA{KeyDelimiter}ParamC=null",
-                keyProvider.CreateVaryKey(httpContext, new VaryRules()
+                keyProvider.CreateStorageVaryKey(httpContext, new VaryRules()
                 {
                     Params = new string[] { "ParamA", "ParamC" }
                 }));
         }
 
         [Fact]
-        public void DefaultKeyProvider_CreateVaryKey_IncludesAllQueryParamsGivenAsterisk()
+        public void DefaultKeyProvider_CreateStorageVaryKey_IncludesAllQueryParamsGivenAsterisk()
         {
             var httpContext = CreateDefaultContext();
             httpContext.Request.QueryString = new QueryString("?ParamA=ValueA&ParamB=ValueB");
@@ -124,14 +124,14 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             // To support case insensitivity, all param keys are converted to upper case.
             // Explicit params uses the casing specified in the setting.
             Assert.Equal($"{TestVaryRules.VaryKeyPrefix}{KeyDelimiter}Q{KeyDelimiter}PARAMA=ValueA{KeyDelimiter}PARAMB=ValueB",
-                keyProvider.CreateVaryKey(httpContext, new VaryRules()
+                keyProvider.CreateStorageVaryKey(httpContext, new VaryRules()
                 {
                     Params = new string[] { "*" }
                 }));
         }
 
         [Fact]
-        public void DefaultKeyProvider_CreateVaryKey_IncludesListedHeadersAndParams()
+        public void DefaultKeyProvider_CreateStorageVaryKey_IncludesListedHeadersAndParams()
         {
             var httpContext = CreateDefaultContext();
             httpContext.Request.Headers["HeaderA"] = "ValueA";
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             var keyProvider = CreateTestKeyProvider();
 
             Assert.Equal($"{TestVaryRules.VaryKeyPrefix}{KeyDelimiter}H{KeyDelimiter}HeaderA=ValueA{KeyDelimiter}HeaderC=null{KeyDelimiter}Q{KeyDelimiter}ParamA=ValueA{KeyDelimiter}ParamC=null",
-                keyProvider.CreateVaryKey(httpContext, new VaryRules()
+                keyProvider.CreateStorageVaryKey(httpContext, new VaryRules()
                 {
                     Headers = new string[] { "HeaderA", "HeaderC" },
                     Params = new string[] { "ParamA", "ParamC" }


### PR DESCRIPTION
Adding support for multiple lookup keys. This will allow for scenarios such as varyby content encoding and using a cached response of a GET request to satisfy a HEAD response.

Pending #30