### PR TITLE
StringBuilder extension to uppercase string

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCacheKeyProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCacheKeyProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.ResponseCaching.Internal;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -54,11 +55,19 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
             try
             {
                 builder
-                    .Append(request.Method.ToUpperInvariant())
-                    .Append(KeyDelimiter)
-                    .Append(_options.UseCaseSensitivePaths ? request.Path.Value : request.Path.Value.ToUpperInvariant());
+                    .AppendUpperInvariant(request.Method)
+                    .Append(KeyDelimiter);
 
-                return builder.ToString();;
+                if (_options.UseCaseSensitivePaths)
+                {
+                    builder.Append(request.Path.Value);
+                }
+                else
+                {
+                    builder.AppendUpperInvariant(request.Path.Value);
+                }
+
+                return builder.ToString();
             }
             finally
             {
@@ -123,7 +132,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
                         foreach (var query in context.HttpContext.Request.Query.OrderBy(q => q.Key, StringComparer.OrdinalIgnoreCase))
                         {
                             builder.Append(KeyDelimiter)
-                                .Append(query.Key.ToUpperInvariant())
+                                .AppendUpperInvariant(query.Key)
                                 .Append("=")
                                 .Append(query.Value);
                         }

--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/StringBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/StringBuilderExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+
+namespace Microsoft.AspNetCore.ResponseCaching.Internal
+{
+    internal static class StringBuilderExtensions
+    {
+        internal static StringBuilder AppendUpperInvariant(this StringBuilder builder, string value)
+        {
+            builder.EnsureCapacity(builder.Length + value.Length);
+            for (var i = 0; i < value.Length; i++)
+            {
+                builder.Append(char.ToUpperInvariant(value[i]));
+            }
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
Saves `~84` bytes per request
I was getting a range of `~2.6%` to `~8.1%` performance increase. Would like to test it with benchmarks when we add ResponseCaching tests to it.