### PR TITLE
 Use 1.0.0 dependencies

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
+    <clear />
+    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/samples/ResponseCachingSample/project.json
+++ b/samples/ResponseCachingSample/project.json
@@ -1,10 +1,9 @@
 {
-  "version": "1.1.0-*",
   "dependencies": {
-    "Microsoft.AspNetCore.ResponseCaching": "1.0.0-*",
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.1.0-*",
-    "Microsoft.Extensions.Caching.Memory": "1.1.0-*"
+    "Microsoft.AspNetCore.ResponseCaching": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.Extensions.Caching.Memory": "1.0.0"
   },
   "buildOptions": {
     "emitEntryPoint": true
@@ -14,7 +13,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.0.0",
           "type": "platform"
         }
       }

--- a/src/Microsoft.AspNetCore.ResponseCaching.Abstractions/project.json
+++ b/src/Microsoft.AspNetCore.ResponseCaching.Abstractions/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-*",
+  "version": "1.0.0",
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",
@@ -18,14 +18,10 @@
     ]
   },
   "dependencies": {
-    "Microsoft.Extensions.Primitives": "1.1.0-*"
+    "Microsoft.Extensions.Primitives": "1.0.0"
   },
   "frameworks": {
     "net451": {},
-    "netstandard1.3": {
-      "dependencies": {
-        "NETStandard.Library": "1.6.1-*"
-      }
-    }
+    "netstandard1.3": {}
   }
 }

--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachePolicyProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachePolicyProvider.cs
@@ -16,7 +16,8 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
         {
             // Verify the method
             var request = context.HttpContext.Request;
-            if (!HttpMethods.IsGet(request.Method) && !HttpMethods.IsHead(request.Method))
+            if (!string.Equals("GET", request.Method, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals("HEAD", request.Method, StringComparison.OrdinalIgnoreCase))
             {
                 context.Logger.LogRequestMethodNotCacheable(request.Method);
                 return false;

--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/TaskCache.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/TaskCache.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.Internal
+{
+    internal static class TaskCache
+    {
+        /// <summary>
+        /// A <see cref="Task"/> that's already completed successfully.
+        /// </summary>
+        /// <remarks>
+        /// We're caching this in a static readonly field to make it more inlinable and avoid the volatile lookup done
+        /// by <c>Task.CompletedTask</c>.
+        /// </remarks>
+#if NET451
+        public static readonly Task CompletedTask = Task.FromResult(0);
+#else
+        public static readonly Task CompletedTask = Task.CompletedTask;
+#endif
+    }
+}

--- a/src/Microsoft.AspNetCore.ResponseCaching/ResponseCacheMiddleware.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/ResponseCacheMiddleware.cs
@@ -362,7 +362,7 @@ namespace Microsoft.AspNetCore.ResponseCaching
                 {
                     foreach (var tag in ifNoneMatchHeader)
                     {
-                        if (cachedResponseHeaders.ETag.Compare(tag, useStrongComparison: false))
+                        if (string.Equals(cachedResponseHeaders.ETag.Tag, tag.Tag, StringComparison.Ordinal))
                         {
                             context.Logger.LogNotModifiedIfNoneMatchMatched(tag);
                             return true;

--- a/src/Microsoft.AspNetCore.ResponseCaching/project.json
+++ b/src/Microsoft.AspNetCore.ResponseCaching/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.0.0",
   "buildOptions": {
     "warningsAsErrors": true,
     "allowUnsafe": true,
@@ -22,16 +22,11 @@
     ]
   },
   "dependencies": {
-    "Microsoft.AspNetCore.Http": "1.1.0-*",
-    "Microsoft.AspNetCore.Http.Extensions": "1.1.0-*",
-    "Microsoft.AspNetCore.ResponseCaching.Abstractions": "1.0.0-*",
-    "Microsoft.Extensions.Caching.Memory": "1.1.0-*",
-    "Microsoft.Extensions.Logging.Abstractions": "1.1.0-*",
-    "Microsoft.Extensions.TaskCache.Sources": {
-      "version": "1.1.0-*",
-      "type": "build"
-    },
-    "NETStandard.Library": "1.6.1-*"
+    "Microsoft.AspNetCore.Http": "1.0.0",
+    "Microsoft.AspNetCore.Http.Extensions": "1.0.0",
+    "Microsoft.AspNetCore.ResponseCaching.Abstractions": "1.0.0",
+    "Microsoft.Extensions.Caching.Memory": "1.0.0",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0"
   },
   "frameworks": {
     "net451": {},

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachePolicyProviderTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachePolicyProviderTests.cs
@@ -295,7 +295,6 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         [InlineData(StatusCodes.Status204NoContent)]
         [InlineData(StatusCodes.Status205ResetContent)]
         [InlineData(StatusCodes.Status206PartialContent)]
-        [InlineData(StatusCodes.Status207MultiStatus)]
         [InlineData(StatusCodes.Status300MultipleChoices)]
         [InlineData(StatusCodes.Status301MovedPermanently)]
         [InlineData(StatusCodes.Status302Found)]
@@ -304,7 +303,6 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         [InlineData(StatusCodes.Status305UseProxy)]
         [InlineData(StatusCodes.Status306SwitchProxy)]
         [InlineData(StatusCodes.Status307TemporaryRedirect)]
-        [InlineData(StatusCodes.Status308PermanentRedirect)]
         [InlineData(StatusCodes.Status400BadRequest)]
         [InlineData(StatusCodes.Status401Unauthorized)]
         [InlineData(StatusCodes.Status402PaymentRequired)]
@@ -325,10 +323,6 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         [InlineData(StatusCodes.Status417ExpectationFailed)]
         [InlineData(StatusCodes.Status418ImATeapot)]
         [InlineData(StatusCodes.Status419AuthenticationTimeout)]
-        [InlineData(StatusCodes.Status422UnprocessableEntity)]
-        [InlineData(StatusCodes.Status423Locked)]
-        [InlineData(StatusCodes.Status424FailedDependency)]
-        [InlineData(StatusCodes.Status451UnavailableForLegalReasons)]
         [InlineData(StatusCodes.Status500InternalServerError)]
         [InlineData(StatusCodes.Status501NotImplemented)]
         [InlineData(StatusCodes.Status502BadGateway)]
@@ -336,7 +330,6 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         [InlineData(StatusCodes.Status504GatewayTimeout)]
         [InlineData(StatusCodes.Status505HttpVersionNotsupported)]
         [InlineData(StatusCodes.Status506VariantAlsoNegotiates)]
-        [InlineData(StatusCodes.Status507InsufficientStorage)]
         public void IsResponseCacheable_NonSuccessStatusCodes_NotAllowed(int statusCode)
         {
             var sink = new TestSink();

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestUtils.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestUtils.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             };
         }
 
-        internal static ResponseCacheContext CreateTestContext(ITestSink testSink)
+        internal static ResponseCacheContext CreateTestContext(TestSink testSink)
         {
             return new ResponseCacheContext(new DefaultHttpContext(), new TestLogger("ResponseCachingTests", testSink, true))
             {
@@ -144,6 +144,19 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 Assert.Equal(expectedMessages[i].LogLevel, messages[i].LogLevel);
             }
         }
+    }
+
+    internal static class HttpMethods
+    {
+        public static readonly string Connect = "CONNECT";
+        public static readonly string Delete = "DELETE";
+        public static readonly string Get = "GET";
+        public static readonly string Head = "HEAD";
+        public static readonly string Options = "OPTIONS";
+        public static readonly string Patch = "PATCH";
+        public static readonly string Post = "POST";
+        public static readonly string Put = "PUT";
+        public static readonly string Trace = "TRACE";
     }
 
     internal class LoggedMessage

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/project.json
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/project.json
@@ -4,20 +4,24 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.AspNetCore.ResponseCaching": "1.0.0-*",
-    "Microsoft.AspNetCore.TestHost": "1.1.0-*",
-    "Microsoft.Extensions.Logging.Testing": "1.1.0-*",
-    "xunit": "2.2.0-*"
+    "dotnet-test-xunit": "1.0.0-rc3-000000-01",
+    "Microsoft.AspNetCore.ResponseCaching": "1.0.0",
+    "Microsoft.AspNetCore.TestHost": "1.0.0",
+    "Microsoft.Extensions.Logging.Testing": "1.0.0",
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.0.0",
           "type": "platform"
         }
-      }
+      },
+      "imports": [
+        "dnxcore50",
+        "portable-net451+win8"
+      ]
     },
     "net451": {}
   },


### PR DESCRIPTION
Not merging this yet, just to illustrate what is changed when reverting to 1.0.0 dependencies.