### PR TITLE
Optimizations

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/CacheEntry/CachedResponse.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/CacheEntry/CachedResponse.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
 
         public int StatusCode { get; set; }
 
-        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+        public IHeaderDictionary Headers { get; set; }
 
         public Stream Body { get; set; }
     }

--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/MemoryResponseCache.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/MemoryResponseCache.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.ResponseCaching.Internal
 {

--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachingKeyProvider.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachingKeyProvider.cs
@@ -107,13 +107,18 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
                     builder.Append(KeyDelimiter)
                         .Append('H');
 
-                    foreach (var header in varyByRules.Headers)
+                    for (var i = 0; i < varyByRules.Headers.Count; i++)
                     {
+                        var header = varyByRules.Headers[i];
+                        var headerValues = context.HttpContext.Request.Headers[header];
                         builder.Append(KeyDelimiter)
                             .Append(header)
-                            .Append("=")
-                            // TODO: Perf - iterate the string values instead?
-                            .Append(context.HttpContext.Request.Headers[header]);
+                            .Append("=");
+
+                        for (var j = 0; j < headerValues.Count; j++)
+                        {
+                            builder.Append(headerValues[j]);
+                        }
                     }
                 }
 
@@ -131,19 +136,28 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
                         {
                             builder.Append(KeyDelimiter)
                                 .AppendUpperInvariant(query.Key)
-                                .Append("=")
-                                .Append(query.Value);
+                                .Append("=");
+
+                            for (var i = 0; i < query.Value.Count; i++)
+                            {
+                                builder.Append(query.Value[i]);
+                            }
                         }
                     }
                     else
                     {
-                        foreach (var queryKey in varyByRules.QueryKeys)
+                        for (var i = 0; i < varyByRules.QueryKeys.Count; i++)
                         {
+                            var queryKey = varyByRules.QueryKeys[i];
+                            var queryKeyValues = context.HttpContext.Request.Query[queryKey];
                             builder.Append(KeyDelimiter)
                                 .Append(queryKey)
-                                .Append("=")
-                                // TODO: Perf - iterate the string values instead?
-                                .Append(context.HttpContext.Request.Query[queryKey]);
+                                .Append("=");
+
+                            for (var j = 0; j < queryKeyValues.Count; j++)
+                            {
+                                builder.Append(queryKeyValues[j]);
+                            }
                         }
                     }
                 }

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingMiddlewareTests.cs
@@ -61,6 +61,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 "BaseKey",
                 new CachedResponse()
                 {
+                    Headers = new HeaderDictionary(),
                     Body = new SegmentReadStream(new List<byte[]>(0), 0)
                 },
                 TimeSpan.Zero);
@@ -108,6 +109,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 "BaseKeyVaryKey2",
                 new CachedResponse()
                 {
+                    Headers = new HeaderDictionary(),
                     Body = new SegmentReadStream(new List<byte[]>(0), 0)
                 },
                 TimeSpan.Zero);
@@ -666,7 +668,10 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             await context.HttpContext.Response.WriteAsync(new string('0', 10));
 
             context.ShouldCacheResponse = true;
-            context.CachedResponse = new CachedResponse();
+            context.CachedResponse = new CachedResponse()
+            {
+                Headers = new HeaderDictionary()
+            };
             context.BaseKey = "BaseKey";
             context.CachedResponseValidFor = TimeSpan.FromSeconds(10);
 


### PR DESCRIPTION
While I was looking at the allocation saving on #70 I noticed a few quick optimizations. 

Before: 346747.2 RPS, 1205.3 bytes/req (net451), 848.6 bytes/req (netcore)
After: 434507.1 RPS, 1158.9 bytes/req (net451), 802.8 bytes/req (netcore)

@BrennanConroy @Tratcher 