### PR TITLE
Use If-Modified-Since instead of the incorrect If-Unmodified-Since header

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/LoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/LoggerExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
         private static Action<ILogger, int, Exception> _logResponseWithUnsuccessfulStatusCodeNotCacheable;
         private static Action<ILogger, Exception> _logNotModifiedIfNoneMatchStar;
         private static Action<ILogger, EntityTagHeaderValue, Exception> _logNotModifiedIfNoneMatchMatched;
-        private static Action<ILogger, DateTimeOffset, DateTimeOffset, Exception> _logNotModifiedIfUnmodifiedSinceSatisfied;
+        private static Action<ILogger, DateTimeOffset, DateTimeOffset, Exception> _logNotModifiedIfModifiedSinceSatisfied;
         private static Action<ILogger, Exception> _logNotModifiedServed;
         private static Action<ILogger, Exception> _logCachedResponseServed;
         private static Action<ILogger, Exception> _logGatewayTimeoutServed;
@@ -119,10 +119,10 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
                 logLevel: LogLevel.Debug,
                 eventId: 19,
                 formatString: $"The ETag {{ETag}} in the '{HeaderNames.IfNoneMatch}' header matched the ETag of a cached entry.");
-            _logNotModifiedIfUnmodifiedSinceSatisfied = LoggerMessage.Define<DateTimeOffset, DateTimeOffset>(
+            _logNotModifiedIfModifiedSinceSatisfied = LoggerMessage.Define<DateTimeOffset, DateTimeOffset>(
                 logLevel: LogLevel.Debug,
                 eventId: 20,
-                formatString: $"The last modified date of {{LastModified}} is before the date {{IfUnmodifiedSince}} specified in the '{HeaderNames.IfUnmodifiedSince}' header.");
+                formatString: $"The last modified date of {{LastModified}} is before the date {{IfModifiedSince}} specified in the '{HeaderNames.IfModifiedSince}' header.");
             _logNotModifiedServed = LoggerMessage.Define(
                 logLevel: LogLevel.Information,
                 eventId: 21,
@@ -252,9 +252,9 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
             _logNotModifiedIfNoneMatchMatched(logger, etag, null);
         }
 
-        internal static void LogNotModifiedIfUnmodifiedSinceSatisfied(this ILogger logger, DateTimeOffset lastModified, DateTimeOffset ifUnmodifiedSince)
+        internal static void LogNotModifiedIfModifiedSinceSatisfied(this ILogger logger, DateTimeOffset lastModified, DateTimeOffset ifModifiedSince)
         {
-            _logNotModifiedIfUnmodifiedSinceSatisfied(logger, lastModified, ifUnmodifiedSince, null);
+            _logNotModifiedIfModifiedSinceSatisfied(logger, lastModified, ifModifiedSince, null);
         }
 
         internal static void LogNotModifiedServed(this ILogger logger)

--- a/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingMiddleware.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingMiddleware.cs
@@ -371,13 +371,13 @@ namespace Microsoft.AspNetCore.ResponseCaching
             }
             else
             {
-                var ifUnmodifiedSince = context.TypedRequestHeaders.IfUnmodifiedSince;
-                if (ifUnmodifiedSince != null)
+                var ifModifiedSince = context.TypedRequestHeaders.IfModifiedSince;
+                if (ifModifiedSince != null)
                 {
                     var lastModified = cachedResponseHeaders.LastModified ?? cachedResponseHeaders.Date;
-                    if (lastModified <= ifUnmodifiedSince)
+                    if (lastModified <= ifModifiedSince)
                     {
-                        context.Logger.LogNotModifiedIfUnmodifiedSinceSatisfied(lastModified.Value, ifUnmodifiedSince.Value);
+                        context.Logger.LogNotModifiedIfModifiedSinceSatisfied(lastModified.Value, ifModifiedSince.Value);
                         return true;
                     }
                 }

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingMiddlewareTests.cs
@@ -156,14 +156,14 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         }
 
         [Fact]
-        public void ContentIsNotModified_IfUnmodifiedSince_FallsbackToDateHeader()
+        public void ContentIsNotModified_IfModifiedSince_FallsbackToDateHeader()
         {
             var utcNow = DateTimeOffset.UtcNow;
             var sink = new TestSink();
             var context = TestUtils.CreateTestContext(sink);
             context.CachedResponseHeaders = new ResponseHeaders(new HeaderDictionary());
 
-            context.TypedRequestHeaders.IfUnmodifiedSince = utcNow;
+            context.TypedRequestHeaders.IfModifiedSince = utcNow;
 
             // Verify modifications in the past succeeds
             context.CachedResponseHeaders.Date = utcNow - TimeSpan.FromSeconds(10);
@@ -182,19 +182,19 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             // Verify logging
             TestUtils.AssertLoggedMessages(
                 sink.Writes,
-                LoggedMessage.NotModifiedIfUnmodifiedSinceSatisfied,
-                LoggedMessage.NotModifiedIfUnmodifiedSinceSatisfied);
+                LoggedMessage.NotModifiedIfModifiedSinceSatisfied,
+                LoggedMessage.NotModifiedIfModifiedSinceSatisfied);
         }
 
         [Fact]
-        public void ContentIsNotModified_IfUnmodifiedSince_LastModifiedOverridesDateHeader()
+        public void ContentIsNotModified_IfModifiedSince_LastModifiedOverridesDateHeader()
         {
             var utcNow = DateTimeOffset.UtcNow;
             var sink = new TestSink();
             var context = TestUtils.CreateTestContext(sink);
             context.CachedResponseHeaders = new ResponseHeaders(new HeaderDictionary());
 
-            context.TypedRequestHeaders.IfUnmodifiedSince = utcNow;
+            context.TypedRequestHeaders.IfModifiedSince = utcNow;
 
             // Verify modifications in the past succeeds
             context.CachedResponseHeaders.Date = utcNow + TimeSpan.FromSeconds(10);
@@ -216,20 +216,20 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             // Verify logging
             TestUtils.AssertLoggedMessages(
                 sink.Writes,
-                LoggedMessage.NotModifiedIfUnmodifiedSinceSatisfied,
-                LoggedMessage.NotModifiedIfUnmodifiedSinceSatisfied);
+                LoggedMessage.NotModifiedIfModifiedSinceSatisfied,
+                LoggedMessage.NotModifiedIfModifiedSinceSatisfied);
         }
 
         [Fact]
-        public void ContentIsNotModified_IfNoneMatch_Overrides_IfUnmodifiedSince_ToTrue()
+        public void ContentIsNotModified_IfNoneMatch_Overrides_IfModifiedSince_ToTrue()
         {
             var utcNow = DateTimeOffset.UtcNow;
             var sink = new TestSink();
             var context = TestUtils.CreateTestContext(sink);
             context.CachedResponseHeaders = new ResponseHeaders(new HeaderDictionary());
 
-            // This would fail the IfUnmodifiedSince checks
-            context.TypedRequestHeaders.IfUnmodifiedSince = utcNow;
+            // This would fail the IfModifiedSince checks
+            context.TypedRequestHeaders.IfModifiedSince = utcNow;
             context.CachedResponseHeaders.LastModified = utcNow + TimeSpan.FromSeconds(10);
 
             context.TypedRequestHeaders.IfNoneMatch = new List<EntityTagHeaderValue>(new[] { EntityTagHeaderValue.Any });
@@ -240,15 +240,15 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         }
 
         [Fact]
-        public void ContentIsNotModified_IfNoneMatch_Overrides_IfUnmodifiedSince_ToFalse()
+        public void ContentIsNotModified_IfNoneMatch_Overrides_IfModifiedSince_ToFalse()
         {
             var utcNow = DateTimeOffset.UtcNow;
             var sink = new TestSink();
             var context = TestUtils.CreateTestContext(sink);
             context.CachedResponseHeaders = new ResponseHeaders(new HeaderDictionary());
 
-            // This would pass the IfUnmodifiedSince checks
-            context.TypedRequestHeaders.IfUnmodifiedSince = utcNow;
+            // This would pass the IfModifiedSince checks
+            context.TypedRequestHeaders.IfModifiedSince = utcNow;
             context.CachedResponseHeaders.LastModified = utcNow - TimeSpan.FromSeconds(10);
 
             context.TypedRequestHeaders.IfNoneMatch = new List<EntityTagHeaderValue>(new[] { new EntityTagHeaderValue("\"E1\"") });

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingTests.cs
@@ -453,7 +453,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 {
                     var client = server.CreateClient();
                     var initialResponse = await client.GetAsync("");
-                    client.DefaultRequestHeaders.IfUnmodifiedSince = DateTimeOffset.MaxValue;
+                    client.DefaultRequestHeaders.IfModifiedSince = DateTimeOffset.MaxValue;
                     var subsequentResponse = await client.GetAsync("");
 
                     initialResponse.EnsureSuccessStatusCode();
@@ -473,7 +473,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 {
                     var client = server.CreateClient();
                     var initialResponse = await client.GetAsync("");
-                    client.DefaultRequestHeaders.IfUnmodifiedSince = DateTimeOffset.MinValue;
+                    client.DefaultRequestHeaders.IfModifiedSince = DateTimeOffset.MinValue;
                     var subsequentResponse = await client.GetAsync("");
 
                     await AssertCachedResponseAsync(initialResponse, subsequentResponse);

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestUtils.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestUtils.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         internal static LoggedMessage ResponseWithUnsuccessfulStatusCodeNotCacheable => new LoggedMessage(17, LogLevel.Debug);
         internal static LoggedMessage NotModifiedIfNoneMatchStar => new LoggedMessage(18, LogLevel.Debug);
         internal static LoggedMessage NotModifiedIfNoneMatchMatched => new LoggedMessage(19, LogLevel.Debug);
-        internal static LoggedMessage NotModifiedIfUnmodifiedSinceSatisfied => new LoggedMessage(20, LogLevel.Debug);
+        internal static LoggedMessage NotModifiedIfModifiedSinceSatisfied => new LoggedMessage(20, LogLevel.Debug);
         internal static LoggedMessage NotModifiedServed => new LoggedMessage(21, LogLevel.Information);
         internal static LoggedMessage CachedResponseServed => new LoggedMessage(22, LogLevel.Information);
         internal static LoggedMessage GatewayTimeoutServed => new LoggedMessage(23, LogLevel.Information);


### PR DESCRIPTION
Patch PR for #89.

Fixes:
- Using `If-Modified-Since` instead of the incorrect `If-Unmodified-Since` header