### PR TITLE
ResponseCaching Patch 1.1.1

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/LoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/LoggerExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
         private static Action<ILogger, int, Exception> _logResponseWithUnsuccessfulStatusCodeNotCacheable;
         private static Action<ILogger, Exception> _logNotModifiedIfNoneMatchStar;
         private static Action<ILogger, EntityTagHeaderValue, Exception> _logNotModifiedIfNoneMatchMatched;
-        private static Action<ILogger, DateTimeOffset, DateTimeOffset, Exception> _logNotModifiedIfUnmodifiedSinceSatisfied;
+        private static Action<ILogger, DateTimeOffset, DateTimeOffset, Exception> _logNotModifiedIfModifiedSinceSatisfied;
         private static Action<ILogger, Exception> _logNotModifiedServed;
         private static Action<ILogger, Exception> _logCachedResponseServed;
         private static Action<ILogger, Exception> _logGatewayTimeoutServed;
@@ -119,10 +119,10 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
                 logLevel: LogLevel.Debug,
                 eventId: 19,
                 formatString: $"The ETag {{ETag}} in the '{HeaderNames.IfNoneMatch}' header matched the ETag of a cached entry.");
-            _logNotModifiedIfUnmodifiedSinceSatisfied = LoggerMessage.Define<DateTimeOffset, DateTimeOffset>(
+            _logNotModifiedIfModifiedSinceSatisfied = LoggerMessage.Define<DateTimeOffset, DateTimeOffset>(
                 logLevel: LogLevel.Debug,
                 eventId: 20,
-                formatString: $"The last modified date of {{LastModified}} is before the date {{IfUnmodifiedSince}} specified in the '{HeaderNames.IfUnmodifiedSince}' header.");
+                formatString: $"The last modified date of {{LastModified}} is before the date {{IfModifiedSince}} specified in the '{HeaderNames.IfModifiedSince}' header.");
             _logNotModifiedServed = LoggerMessage.Define(
                 logLevel: LogLevel.Information,
                 eventId: 21,
@@ -252,9 +252,9 @@ namespace Microsoft.AspNetCore.ResponseCaching.Internal
             _logNotModifiedIfNoneMatchMatched(logger, etag, null);
         }
 
-        internal static void LogNotModifiedIfUnmodifiedSinceSatisfied(this ILogger logger, DateTimeOffset lastModified, DateTimeOffset ifUnmodifiedSince)
+        internal static void LogNotModifiedIfModifiedSinceSatisfied(this ILogger logger, DateTimeOffset lastModified, DateTimeOffset ifModifiedSince)
         {
-            _logNotModifiedIfUnmodifiedSinceSatisfied(logger, lastModified, ifUnmodifiedSince, null);
+            _logNotModifiedIfModifiedSinceSatisfied(logger, lastModified, ifModifiedSince, null);
         }
 
         internal static void LogNotModifiedServed(this ILogger logger)

--- a/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingMiddleware.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingMiddleware.cs
@@ -106,7 +106,17 @@ namespace Microsoft.AspNetCore.ResponseCaching
             }
             else
             {
-                await _next(httpContext);
+                // Add IResponseCachingFeature which may be required when the response is generated
+                AddResponseCachingFeature(httpContext);
+
+                try
+                {
+                    await _next(httpContext);
+                }
+                finally
+                {
+                    RemoveResponseCachingFeature(httpContext);
+                }
             }
         }
 
@@ -318,6 +328,15 @@ namespace Microsoft.AspNetCore.ResponseCaching
             }
         }
 
+        internal static void AddResponseCachingFeature(HttpContext context)
+        {
+            if (context.Features.Get<IResponseCachingFeature>() != null)
+            {
+                throw new InvalidOperationException($"Another instance of {nameof(IResponseCachingFeature)} already exists. Only one instance of {nameof(ResponseCachingMiddleware)} can be configured for an application.");
+            }
+            context.Features.Set<IResponseCachingFeature>(new ResponseCachingFeature());
+        }
+
         internal void ShimResponseStream(ResponseCachingContext context)
         {
             // Shim response stream
@@ -332,13 +351,11 @@ namespace Microsoft.AspNetCore.ResponseCaching
                 context.HttpContext.Features.Set<IHttpSendFileFeature>(new SendFileFeatureWrapper(context.OriginalSendFileFeature, context.ResponseCachingStream));
             }
 
-            // Add IResponseCachingFeature
-            if (context.HttpContext.Features.Get<IResponseCachingFeature>() != null)
-            {
-                throw new InvalidOperationException($"Another instance of {nameof(ResponseCachingFeature)} already exists. Only one instance of {nameof(ResponseCachingMiddleware)} can be configured for an application.");
-            }
-            context.HttpContext.Features.Set<IResponseCachingFeature>(new ResponseCachingFeature());
+            AddResponseCachingFeature(context.HttpContext);
         }
+
+        internal static void RemoveResponseCachingFeature(HttpContext context)
+            => context.Features.Set<IResponseCachingFeature>(null);
 
         internal static void UnshimResponseStream(ResponseCachingContext context)
         {
@@ -349,7 +366,7 @@ namespace Microsoft.AspNetCore.ResponseCaching
             context.HttpContext.Features.Set(context.OriginalSendFileFeature);
 
             // Remove IResponseCachingFeature
-            context.HttpContext.Features.Set<IResponseCachingFeature>(null);
+            RemoveResponseCachingFeature(context.HttpContext);
         }
 
         internal static bool ContentIsNotModified(ResponseCachingContext context)
@@ -379,13 +396,13 @@ namespace Microsoft.AspNetCore.ResponseCaching
             }
             else
             {
-                var ifUnmodifiedSince = context.TypedRequestHeaders.IfUnmodifiedSince;
-                if (ifUnmodifiedSince != null)
+                var ifModifiedSince = context.TypedRequestHeaders.IfModifiedSince;
+                if (ifModifiedSince != null)
                 {
                     var lastModified = cachedResponseHeaders.LastModified ?? cachedResponseHeaders.Date;
-                    if (lastModified <= ifUnmodifiedSince)
+                    if (lastModified <= ifModifiedSince)
                     {
-                        context.Logger.LogNotModifiedIfUnmodifiedSinceSatisfied(lastModified.Value, ifUnmodifiedSince.Value);
+                        context.Logger.LogNotModifiedIfModifiedSinceSatisfied(lastModified.Value, ifModifiedSince.Value);
                         return true;
                     }
                 }

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingTests.cs
@@ -619,7 +619,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 {
                     var client = server.CreateClient();
                     var initialResponse = await client.GetAsync("");
-                    client.DefaultRequestHeaders.IfUnmodifiedSince = DateTimeOffset.MaxValue;
+                    client.DefaultRequestHeaders.IfModifiedSince = DateTimeOffset.MaxValue;
                     var subsequentResponse = await client.GetAsync("");
 
                     initialResponse.EnsureSuccessStatusCode();
@@ -639,7 +639,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 {
                     var client = server.CreateClient();
                     var initialResponse = await client.GetAsync("");
-                    client.DefaultRequestHeaders.IfUnmodifiedSince = DateTimeOffset.MinValue;
+                    client.DefaultRequestHeaders.IfModifiedSince = DateTimeOffset.MinValue;
                     var subsequentResponse = await client.GetAsync("");
 
                     await AssertCachedResponseAsync(initialResponse, subsequentResponse);

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestUtils.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestUtils.cs
@@ -103,12 +103,17 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         }
 
         internal static ResponseCachingMiddleware CreateTestMiddleware(
+            RequestDelegate next = null,
             IResponseCache cache = null,
             ResponseCachingOptions options = null,
             TestSink testSink = null,
             IResponseCachingKeyProvider keyProvider = null,
             IResponseCachingPolicyProvider policyProvider = null)
         {
+            if (next == null)
+            {
+                next = httpContext => TaskCache.CompletedTask;
+            }
             if (cache == null)
             {
                 cache = new TestResponseCache();
@@ -127,7 +132,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             }
 
             return new ResponseCachingMiddleware(
-                httpContext => TaskCache.CompletedTask,
+                next,
                 Options.Create(options),
                 testSink == null ? (ILoggerFactory)NullLoggerFactory.Instance : new TestLoggerFactory(testSink, true),
                 policyProvider,
@@ -188,7 +193,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         internal static LoggedMessage ResponseWithUnsuccessfulStatusCodeNotCacheable => new LoggedMessage(17, LogLevel.Debug);
         internal static LoggedMessage NotModifiedIfNoneMatchStar => new LoggedMessage(18, LogLevel.Debug);
         internal static LoggedMessage NotModifiedIfNoneMatchMatched => new LoggedMessage(19, LogLevel.Debug);
-        internal static LoggedMessage NotModifiedIfUnmodifiedSinceSatisfied => new LoggedMessage(20, LogLevel.Debug);
+        internal static LoggedMessage NotModifiedIfModifiedSinceSatisfied => new LoggedMessage(20, LogLevel.Debug);
         internal static LoggedMessage NotModifiedServed => new LoggedMessage(21, LogLevel.Information);
         internal static LoggedMessage CachedResponseServed => new LoggedMessage(22, LogLevel.Information);
         internal static LoggedMessage GatewayTimeoutServed => new LoggedMessage(23, LogLevel.Information);


### PR DESCRIPTION
Patch PR for #91 

Fixes include:
- Using `If-Modified-Since` instead of the incorrect `If-Unmodified-Since` header
- Always adding `IResponseCachingFeature` before calling the next middleware