### PR TITLE
Overwrite headers when serving response from cache (backport to 1.1.1)

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingMiddleware.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingMiddleware.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.ResponseCaching
                     response.StatusCode = context.CachedResponse.StatusCode;
                     foreach (var header in context.CachedResponse.Headers)
                     {
-                        response.Headers.Add(header);
+                        response.Headers[header.Key] = header.Value;
                     }
 
                     response.Headers[HeaderNames.Age] = context.CachedEntryAge.Value.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture);
@@ -280,7 +280,7 @@ namespace Microsoft.AspNetCore.ResponseCaching
                 {
                     if (!string.Equals(header.Key, HeaderNames.Age, StringComparison.OrdinalIgnoreCase))
                     {
-                        context.CachedResponse.Headers.Add(header);
+                        context.CachedResponse.Headers[header.Key] = header.Value;
                     }
                 }
             }


### PR DESCRIPTION
#103 