### PR TITLE
Overwrite headers when serving response from cache (backport to 1.0.1)

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingMiddleware.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingMiddleware.cs
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.ResponseCaching
                     response.StatusCode = context.CachedResponse.StatusCode;
                     foreach (var header in context.CachedResponse.Headers)
                     {
-                        response.Headers.Add(header);
+                        response.Headers[header.Key] = header.Value;
                     }
 
                     response.Headers[HeaderNames.Age] = context.CachedEntryAge.Value.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture);
@@ -262,7 +262,7 @@ namespace Microsoft.AspNetCore.ResponseCaching
                 {
                     if (!string.Equals(header.Key, HeaderNames.Age, StringComparison.OrdinalIgnoreCase))
                     {
-                        context.CachedResponse.Headers.Add(header);
+                        context.CachedResponse.Headers[header.Key] = header.Value;
                     }
                 }
             }

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingMiddlewareTests.cs
@@ -74,6 +74,35 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         }
 
         [Fact]
+        public async Task TryServeFromCacheAsync_CachedResponseFound_OverwritesExistingHeaders()
+        {
+            var cache = new TestResponseCache();
+            var sink = new TestSink();
+            var middleware = TestUtils.CreateTestMiddleware(testSink: sink, cache: cache, keyProvider: new TestResponseCachingKeyProvider("BaseKey"));
+            var context = TestUtils.CreateTestContext();
+
+            context.HttpContext.Response.Headers["MyHeader"] = "OldValue";
+            await cache.SetAsync(
+                "BaseKey",
+                new CachedResponse()
+                {
+                    Headers = new HeaderDictionary()
+                    {
+                        { "MyHeader", "NewValue" }
+                    },
+                    Body = new SegmentReadStream(new List<byte[]>(0), 0)
+                },
+                TimeSpan.Zero);
+
+            Assert.True(await middleware.TryServeFromCacheAsync(context));
+            Assert.Equal("NewValue", context.HttpContext.Response.Headers["MyHeader"]);
+            Assert.Equal(1, cache.GetCount);
+            TestUtils.AssertLoggedMessages(
+                sink.Writes,
+                LoggedMessage.CachedResponseServed);
+        }
+
+        [Fact]
         public async Task TryServeFromCacheAsync_VaryByRuleFound_CachedResponseNotFound_Fails()
         {
             var cache = new TestResponseCache();


### PR DESCRIPTION
#104 