### PR TITLE
Add DiagnosticSource support

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -17,6 +17,7 @@
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview1-26016-05</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.4.1</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.3.1</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -10,6 +10,7 @@
     <MicrosoftAspNetCoreServerKestrelPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreServerKestrelPackageVersion>
     <MicrosoftAspNetCoreTestHostPackageVersion>2.1.0-preview1-27849</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftExtensionsCachingMemoryPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsCachingMemoryPackageVersion>
+    <MicrosoftExtensionsDiagnosticAdapterPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsDiagnosticAdapterPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsLoggingTestingPackageVersion>
     <MicrosoftExtensionsPrimitivesPackageVersion>2.1.0-preview1-27849</MicrosoftExtensionsPrimitivesPackageVersion>

--- a/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachingDiagnosticSourceExtensions.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachingDiagnosticSourceExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.ResponseCaching.Internal
+{
+    public static class ResponseCachingDiagnosticSourceExtensions
+    {
+        private const string BeforeTryServeFromCacheName =
+            "Microsoft.AspNetCore.ResponseCaching.BeforeTryServeFromCache";
+        private const string AfterTryServeFromCacheName =
+            "Microsoft.AspNetCore.ResponseCaching.AfterTryServeFromCache";
+        private const string BeforeCacheResponseName =
+            "Microsoft.AspNetCore.ResponseCaching.BeforeCacheResponse";
+        private const string AfterCacheResponseName =
+            "Microsoft.AspNetCore.ResponseCaching.AfterCacheResponse";
+
+        public static void BeforeTryServeFromCache(this DiagnosticSource diagnosticSource,
+            ResponseCachingContext responseCachingContext)
+        {
+            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(responseCachingContext != null);
+
+            if (diagnosticSource.IsEnabled(BeforeTryServeFromCacheName))
+            {
+                diagnosticSource.Write(BeforeTryServeFromCacheName, new { responseCachingContext });
+            }
+        }
+
+        public static void AfterTryServeFromCache(this DiagnosticSource diagnosticSource,
+            ResponseCachingContext responseCachingContext, bool servedFromCache)
+        {
+            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(responseCachingContext != null);
+
+            if (diagnosticSource.IsEnabled(AfterTryServeFromCacheName))
+            {
+                diagnosticSource.Write(AfterTryServeFromCacheName, new { responseCachingContext, servedFromCache });
+            }
+        }
+
+        public static void BeforeCacheResponse(this DiagnosticSource diagnosticSource,
+            ResponseCachingContext responseCachingContext)
+        {
+            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(responseCachingContext != null);
+
+            if (diagnosticSource.IsEnabled(BeforeCacheResponseName))
+            {
+                diagnosticSource.Write(BeforeCacheResponseName, new { responseCachingContext });
+            }
+        }
+
+        public static void AfterCacheResponse(this DiagnosticSource diagnosticSource,
+            ResponseCachingContext responseCachingContext)
+        {
+            Debug.Assert(diagnosticSource != null);
+            Debug.Assert(responseCachingContext != null);
+
+            if (diagnosticSource.IsEnabled(AfterCacheResponseName))
+            {
+                diagnosticSource.Write(AfterCacheResponseName, new { responseCachingContext });
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.ResponseCaching/Microsoft.AspNetCore.ResponseCaching.csproj
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Microsoft.AspNetCore.ResponseCaching.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourcePackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.ResponseCaching/Microsoft.AspNetCore.ResponseCaching.csproj
+++ b/src/Microsoft.AspNetCore.ResponseCaching/Microsoft.AspNetCore.ResponseCaching.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/Microsoft.AspNetCore.ResponseCaching.Tests.csproj
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/Microsoft.AspNetCore.ResponseCaching.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="$(MicrosoftExtensionsDiagnosticAdapterPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)" />

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestDiagnosticListener.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestDiagnosticListener.cs
@@ -1,0 +1,87 @@
+﻿using System.Diagnostics;
+using Microsoft.Extensions.DiagnosticAdapter;
+
+namespace Microsoft.AspNetCore.ResponseCaching.Tests
+{
+    public class TestDiagnosticListener
+    {
+        public class BeforeTryServeFromCacheData
+        {
+            public IProxyResponseCachingContext ResponseCachingContext { get; set; }
+        }
+
+        public BeforeTryServeFromCacheData BeforeTryServeFromCache { get; set; }
+
+        [DiagnosticName("Microsoft.AspNetCore.ResponseCaching.BeforeTryServeFromCache")]
+        public virtual void OnBeforeTryServeFromCache(IProxyResponseCachingContext responseCachingContext)
+        {
+            BeforeTryServeFromCache = new BeforeTryServeFromCacheData
+            {
+                ResponseCachingContext = responseCachingContext
+            };
+        }
+
+        public class AfterTryServeFromCacheData
+        {
+            public IProxyResponseCachingContext ResponseCachingContext { get; set; }
+            public bool ServedFromCache { get; set; }
+        }
+
+        public AfterTryServeFromCacheData AfterTryServeFromCache { get; set; }
+
+        [DiagnosticName("Microsoft.AspNetCore.ResponseCaching.AfterTryServeFromCache")]
+        public virtual void OnAfterTryServeFromCache(IProxyResponseCachingContext responseCachingContext, bool servedFromCache)
+        {
+            AfterTryServeFromCache = new AfterTryServeFromCacheData
+            {
+                ResponseCachingContext = responseCachingContext,
+                ServedFromCache = servedFromCache
+            };
+        }
+
+        public class BeforeCacheResponseData
+        {
+            public IProxyResponseCachingContext ResponseCachingContext { get; set; }
+        }
+
+        public BeforeCacheResponseData BeforeCacheResponse { get; set; }
+
+        [DiagnosticName("Microsoft.AspNetCore.ResponseCaching.BeforeCacheResponse")]
+        public virtual void OnBeforeCacheResponse(IProxyResponseCachingContext responseCachingContext)
+        {
+            BeforeCacheResponse = new BeforeCacheResponseData
+            {
+                ResponseCachingContext = responseCachingContext
+            };
+        }
+
+        public class AfterCacheResponseData
+        {
+            public IProxyResponseCachingContext ResponseCachingContext { get; set; }
+        }
+
+        public AfterCacheResponseData AfterCacheResponse { get; set; }
+
+        [DiagnosticName("Microsoft.AspNetCore.ResponseCaching.AfterCacheResponse")]
+        public virtual void OnAfterCacheResponse(IProxyResponseCachingContext responseCachingContext)
+        {
+            AfterCacheResponse = new AfterCacheResponseData
+            {
+                ResponseCachingContext = responseCachingContext
+            };
+        }
+
+        public static (DiagnosticSource, TestDiagnosticListener) CreateSourceAndListener(string name = "Microsoft.AspNetCore.ResponseCaching")
+        {
+            var source = new DiagnosticListener(name);
+            var listener = new TestDiagnosticListener();
+            source.SubscribeWithAdapter(listener);
+            return (source, listener);
+        }
+    }
+
+    public interface IProxyResponseCachingContext
+    {
+        
+    }
+}

--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestUtils.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestUtils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -164,7 +165,8 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             ResponseCachingOptions options = null,
             TestSink testSink = null,
             IResponseCachingKeyProvider keyProvider = null,
-            IResponseCachingPolicyProvider policyProvider = null)
+            IResponseCachingPolicyProvider policyProvider = null,
+            DiagnosticSource diagnosticSource = null)
         {
             if (next == null)
             {
@@ -186,6 +188,10 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             {
                 policyProvider = new TestResponseCachingPolicyProvider();
             }
+            if (diagnosticSource == null)
+            {
+                diagnosticSource = new DiagnosticListener("Microsoft.AspNetCore.ResponseCaching");
+            }
 
             return new ResponseCachingMiddleware(
                 next,
@@ -193,7 +199,7 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
                 testSink == null ? (ILoggerFactory)NullLoggerFactory.Instance : new TestLoggerFactory(testSink, true),
                 policyProvider,
                 cache,
-                keyProvider);
+                keyProvider, diagnosticSource);
         }
 
         internal static ResponseCachingContext CreateTestContext()


### PR DESCRIPTION
Old-school ASP.NET has a couple of cache-related events on `HttpApplication` that can be used for metrics.

This change adds four `DiagnosticSource` points under `Microsoft.AspNetCore.ResponseCaching` that can be used for similar metrics in Core:

`BeforeTryServeFromCache` and `AfterTryServeFromCache` covering the cache check, with a flag on `After` to indicate whether the response was served from the cache.

`BeforeCacheResponse` and `AfterCacheResponse` covering the cache write, if done.