### PR TITLE
Sort header and query values

### DIFF
--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingKeyProviderTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingKeyProviderTests.cs
@@ -95,6 +95,22 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         }
 
         [Fact]
+        public void ResponseCachingKeyProvider_CreateStorageVaryKey_HeaderValuesAreSorted()
+        {
+            var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+            var context = TestUtils.CreateTestContext();
+            context.HttpContext.Request.Headers["HeaderA"] = "ValueB";
+            context.HttpContext.Request.Headers.Append("HeaderA", "ValueA");
+            context.CachedVaryByRules = new CachedVaryByRules()
+            {
+                Headers = new string[] { "HeaderA", "HeaderC" }
+            };
+
+            Assert.Equal($"{context.CachedVaryByRules.VaryByKeyPrefix}{KeyDelimiter}H{KeyDelimiter}HeaderA=ValueAValueB{KeyDelimiter}HeaderC=",
+                cacheKeyProvider.CreateStorageVaryByKey(context));
+        }
+
+        [Fact]
         public void ResponseCachingKeyProvider_CreateStorageVaryKey_IncludesListedQueryKeysOnly()
         {
             var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
@@ -150,6 +166,24 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
             var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
             var context = TestUtils.CreateTestContext();
             context.HttpContext.Request.QueryString = new QueryString("?QueryA=ValueA&QueryA=ValueB");
+            context.CachedVaryByRules = new CachedVaryByRules()
+            {
+                VaryByKeyPrefix = FastGuid.NewGuid().IdString,
+                QueryKeys = new string[] { "*" }
+            };
+
+            // To support case insensitivity, all query keys are converted to upper case.
+            // Explicit query keys uses the casing specified in the setting.
+            Assert.Equal($"{context.CachedVaryByRules.VaryByKeyPrefix}{KeyDelimiter}Q{KeyDelimiter}QUERYA=ValueA{KeySubDelimiter}ValueB",
+                cacheKeyProvider.CreateStorageVaryByKey(context));
+        }
+
+        [Fact]
+        public void ResponseCachingKeyProvider_CreateStorageVaryKey_QueryKeysValuesAreSorted()
+        {
+            var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+            var context = TestUtils.CreateTestContext();
+            context.HttpContext.Request.QueryString = new QueryString("?QueryA=ValueB&QueryA=ValueA");
             context.CachedVaryByRules = new CachedVaryByRules()
             {
                 VaryByKeyPrefix = FastGuid.NewGuid().IdString,


### PR DESCRIPTION
Follow up to https://github.com/aspnet/ResponseCaching/pull/156 which addresses https://github.com/aspnet/Home/issues/2810. This might be too much LINQ though. I'll check the performance benchmarks numbers and see if we need to reduce allocations.