### PR TITLE
We don't use the IMemoryCache from DI

### DIFF
--- a/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingServicesExtensions.cs
+++ b/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingServicesExtensions.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.AddMemoryCache();
             services.TryAdd(ServiceDescriptor.Singleton<IResponseCachingPolicyProvider, ResponseCachingPolicyProvider>());
             services.TryAdd(ServiceDescriptor.Singleton<IResponseCachingKeyProvider, ResponseCachingKeyProvider>());
 


### PR DESCRIPTION
Instead we create a private instance: https://github.com/aspnet/ResponseCaching/blob/master/src/Microsoft.AspNetCore.ResponseCaching/ResponseCachingMiddleware.cs#L40-L43