### PR TITLE
Ensure the identical time value is used to assert date in tests

### DIFF
--- a/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingMiddlewareTests.cs
@@ -632,22 +632,18 @@ namespace Microsoft.AspNetCore.ResponseCaching.Tests
         [Fact]
         public async Task FinalizeCacheHeadersAsync_AddsDate_IfNoneSpecified()
         {
-            var clock = new TestClock
-            {
-                UtcNow = DateTimeOffset.UtcNow
-            };
+            var utcNow = DateTimeOffset.UtcNow;
             var sink = new TestSink();
-            var middleware = TestUtils.CreateTestMiddleware(testSink: sink, options: new ResponseCachingOptions
-            {
-                SystemClock = clock
-            });
+            var middleware = TestUtils.CreateTestMiddleware(testSink: sink);
             var context = TestUtils.CreateTestContext();
+            // ResponseTime is the actual value that's used to set the Date header in FinalizeCacheHeadersAsync
+            context.ResponseTime = utcNow;
 
             Assert.True(StringValues.IsNullOrEmpty(context.HttpContext.Response.Headers[HeaderNames.Date]));
 
             await middleware.FinalizeCacheHeadersAsync(context);
 
-            Assert.Equal(HeaderUtilities.FormatDate(clock.UtcNow), context.HttpContext.Response.Headers[HeaderNames.Date]);
+            Assert.Equal(HeaderUtilities.FormatDate(utcNow), context.HttpContext.Response.Headers[HeaderNames.Date]);
             Assert.Empty(sink.Writes);
         }
 


### PR DESCRIPTION
Addresses https://github.com/aspnet/Home/issues/3484.

The test failed because the ResponseTime used to set the Date value has a default value of DateTimeOffset.UtcNow. https://github.com/aspnet/ResponseCaching/blob/master/test/Microsoft.AspNetCore.ResponseCaching.Tests/TestUtils.cs#L204

However, the time we assert with is a value that was obtained via DateTimeOffset.UtcNow from an earlier point in the test, leading to a race in the test https://github.com/aspnet/ResponseCaching/blob/master/test/Microsoft.AspNetCore.ResponseCaching.Tests/ResponseCachingMiddlewareTests.cs#L637.

Normally, ResponseTime will be set according to the SystemClock in the OnStartResponse call that's made before FinalizeCacheHeadersAsync but in this particular test we are calling FinalizeCacheHeadersAsync by itself so we should set the ResponseTime directly to avoid any race in the test.

I scanned the other tests and it seems like this is the only test where we assert dates in this way so this should be the only fix required.